### PR TITLE
expand unix tilde symbol to find session file in home directory

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,6 +19,7 @@ WriteMakefile(
         'List::Util'          => 0,
         'LWP::UserAgent'      => 0,
         'URI::Encode'         => 0,
+        'File::Path::Expand'  => 1.02,
     },
 
     BUILD_REQUIRES => {

--- a/lib/Reddit/Client.pm
+++ b/lib/Reddit/Client.pm
@@ -12,6 +12,7 @@ use JSON           qw//;
 use File::Spec     qw//;
 use Digest::MD5    qw/md5_hex/;
 use POSIX          qw/strftime/;
+use File::Path::Expand qw//;
 
 require Reddit::Client::Account;
 require Reddit::Client::Comment;
@@ -256,7 +257,9 @@ sub save_session {
 
     # Prepare session and file path
     my $session   = { modhash => $self->{modhash}, cookie => $self->{cookie} };
-    my $file_path = defined $file ? $file : $self->{session_file};
+    my $file_path = File::Path::Expand::expand_filename(
+        defined $file ? $file : $self->{session_file}
+    );
 
     DEBUG('Save session to %s', $file_path);
 
@@ -274,7 +277,9 @@ sub save_session {
 sub load_session {
     my ($self, $file) = @_;
     $self->{session_file} || $file || croak 'Expected $file';
-    my $file_path = defined $file ? $file : $self->{session_file};
+    my $file_path = File::Path::Expand::expand_filename(
+        defined $file ? $file : $self->{session_file}
+    );
 
     DEBUG('Load session from %s', $file_path);
 


### PR DESCRIPTION
Running on OSX I provided `~/.reddit` as the session file path, but Perl's open function cannot locate the file. Replacing `~` with `$ENV{HOME}` before opening the file fixes this issue.

I've tested this change on OSX and Debian Linux.

Another solution is using [File::HomeDir](https://metacpan.org/pod/File::HomeDir)